### PR TITLE
Payment 'Line' fix and typo fix

### DIFF
--- a/src/Quickbooks.php
+++ b/src/Quickbooks.php
@@ -413,6 +413,23 @@ class Quickbooks extends \QuickBooks_IPP_Service
             }
         }
 
+        if (isset($data['Line'])) {
+            foreach ($data['Line'] as $line) {
+                $Line = new \QuickBooks_IPP_Object_Line();
+                isset($line['Amount']) ? $Line->setAmount($line['Amount']) : '';
+                if (isset($line['LinkedTxn'])) {
+                    foreach ($line['LinkedTxn'] as $value) {
+                        $LinkedTxn = new \QuickBooks_IPP_Object_LinkedTxn();
+                        isset($value['TxnId']) ? $LinkedTxn->setTxnId($value['TxnId']) : '';
+                        isset($value['TxnType']) ? $LinkedTxn->setTxnType($value['TxnType']) : '';
+                        isset($value['TxnLineId']) ? $LinkedTxn->setTxnLineId($value['TxnLineId']) : '';
+                        $Line->setLinkedTxn($LinkedTxn);
+                    }
+                }
+                $obj->addLine($Line);
+            }
+        }
+
         if (isset($data['LinkedTxn'])) {
             foreach ($data['LinkedTxn'] as $key => $value) {
                 $LinkedTxn = new \QuickBooks_IPP_Object_LinkedTxn();

--- a/src/Quickbooks.php
+++ b/src/Quickbooks.php
@@ -415,7 +415,7 @@ class Quickbooks extends \QuickBooks_IPP_Service
 
         if (isset($data['LinkedTxn'])) {
             foreach ($data['LinkedTxn'] as $key => $value) {
-                $LinkedTxn = new \Quickbooks_IPP_Object_LinkedTxn();
+                $LinkedTxn = new \QuickBooks_IPP_Object_LinkedTxn();
                 isset($value['TxnId']) ? $LinkedTxn->setTxnId($value['TxnId']) : '';
                 isset($value['TxnType']) ? $LinkedTxn->setTxnType($value['TxnType']) : '';
                 isset($value['TxnLineId']) ? $LinkedTxn->setTxnLineId($value['TxnLineId']) : '';


### PR DESCRIPTION
Fixes #6 and a typo when calling ``\QuickBooks_IPP_Object_LinkedTxn()`